### PR TITLE
feat: query top 10 highest-paying remote Data Analyst jobs

### DIFF
--- a/project_sql/1_top_paying_job.sql
+++ b/project_sql/1_top_paying_job.sql
@@ -1,0 +1,26 @@
+/* 
+Question: What are the top-paying data analyst jobs?
+-Identify the top 10 highest-paying Data Analyst roles that are available remotely.
+-Focuses on job postings with specified salaries (remove nulls).
+-Why? Highlight the top-paying opportunities for Data Analysts, offering insights into employment options and salary expectations.
+ */
+
+SELECT
+    job_id,
+    job_title,
+    job_location,
+    job_schedule_type,
+    salary_year_avg,
+    job_posted_date,
+    name AS company_name
+FROM
+    job_postings_fact
+LEFT JOIN
+    company_dim ON job_postings_fact.company_id = company_dim.company_id
+WHERE
+    job_title_short='Data Analyst' AND
+    job_location='Anywhere' AND
+    salary_year_avg IS NOT NULL
+ORDER BY
+    salary_year_avg DESC
+LIMIT 10


### PR DESCRIPTION
### Summary
Added a SQL query to extract the top 10 highest-paying remote Data Analyst job postings.

### Details
- Filters jobs with `job_title_short = 'Data Analyst'` and `job_location = 'Anywhere'`.
- Excludes postings without specified annual salaries (`salary_year_avg IS NOT NULL`).
- Joins with `company_dim` to include company names.
- Sorts by `salary_year_avg` in descending order and limits results to top 10.

### Why?
To surface high-paying remote Data Analyst roles, helping users discover lucrative job opportunities and better understand current salary trends in the field.
