### PR TITLE
Add query to find top-paying skills for Data Analyst roles based on a…

### DIFF
--- a/project_sql/4_top_paying_skills.sql
+++ b/project_sql/4_top_paying_skills.sql
@@ -1,0 +1,55 @@
+/* 
+Questoin: What are the top skills based on salary?
+-Look at the average salary associated with each skill for Data Analyst positions.
+-Focuses on roles with specified salaries, regardless of location.
+-Why? It reveals how different skills impact salary levels for Data Analyst and 
+    helps identify the most financially rewarding skills to acquire or improve.
+ */
+
+SELECT
+    skills,
+    ROUND(AVG(salary_year_avg),0) AS avg_salary
+    
+FROM job_postings_fact
+INNER JOIN skills_job_dim ON job_postings_fact.job_id = skills_job_dim.job_id
+INNER JOIN skills_dim ON skills_job_dim.skill_id = skills_dim.skill_id
+WHERE
+    job_title_short = 'Data Analyst' 
+    AND salary_year_avg IS NOT NULL
+    AND job_location = 'Anywhere'
+  
+GROUP BY
+    skills
+ORDER BY
+    avg_salary DESC
+LIMIT 25
+
+/* Output
+"skills","avg_salary"
+"svn","400000"
+"solidity","179000"
+"couchbase","160515"
+"datarobot","155486"
+"golang","155000"
+"mxnet","149000"
+"dplyr","147633"
+"vmware","147500"
+"terraform","146734"
+"twilio","138500"
+"gitlab","134126"
+"kafka","129999"
+"puppet","129820"
+"keras","127013"
+"pytorch","125226"
+"perl","124686"
+"ansible","124370"
+"hugging face","123950"
+"tensorflow","120647"
+"cassandra","118407"
+"notion","118092"
+"atlassian","117966"
+"bitbucket","116712"
+"airflow","116387"
+"scala","115480"
+
+ */


### PR DESCRIPTION
### Summary

This PR introduces a SQL query that identifies the top skills associated with the highest average salaries for Data Analyst positions. It evaluates roles regardless of location but only includes those with specified salary data.

### Why?

Understanding which skills yield higher salaries can guide both individual career growth and organizational training priorities. This data helps pinpoint the most lucrative skills to focus on.

### Changes

- Joined `job_postings_fact`, `skills_job_dim`, and `skills_dim` tables
- Filtered for Data Analyst roles with non-null salary data
- Calculated the average salary per skill
- Ordered results by highest average salary and limited to top 25 skills

### Insight

This query provides visibility into how certain skills influence compensation, helping identify high-value capabilities in the job market for Data Analysts.
